### PR TITLE
docs: Remove deprecated NixOS references in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Configuration (please fill if applicable):**
-- NixOS version [e.g. 23.11]
+- Debian version [e.g. 11]
 - CPU [e.g. AMD Ryzen 7]
 - GPU(if applicable) [e.g. NVIDIA GTX 1080]
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,5 +33,5 @@ please describe the tests that you ran to verify your changes with reproducible 
 - [ ] Test B
 
 **Test Configuration**:
-* NixOS version:
+* Debian version:
 * Testbed:

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -6,11 +6,11 @@ The following documentation describes any devops practices for this project.
 
 With the exception of non-impacting code changes like documentation, any new pull request should automatically trigger build a liveCD ISO image with the new changes. Unsuccessful builds are not merged into the main branch.
 
-Currently, the automatic build liveCD [workflow](https://github.com/cnshing/nixos-livecd/blob/main/.github/workflows/automatic-build-livecd.yml) only produces ISO live images.
+Currently, the automatic build liveCD [workflow](https://github.com/cnshing/debian-livecd/blob/main/.github/workflows/automatic-build-livecd.yml) only produces ISO live images.
 
 ### Optimizations 
 
-In our current implementation, some builds appear to instantaneously pass but no attempts to actually build the liveCD were made. This behavior is intended for situations where an identical referable build was already made before or when code changes are certain to be non-impactful under the [pre criteria assessment](https://github.com/cnshing/nixos-livecd/blob/main/.github/actions/pre-criteria-assessment/action.yml) module.
+In our current implementation, some builds appear to instantaneously pass but no attempts to actually build the liveCD were made. This behavior is intended for situations where an identical referable build was already made before or when code changes are certain to be non-impactful under the [pre criteria assessment](https://github.com/cnshing/debian-livecd/blob/main/.github/actions/pre-criteria-assessment/action.yml) module.
 
 ## Trunk-based Development
 


### PR DESCRIPTION
## Description

Some links contained references to the old archived respository. This PR aims to replace these references and link them back to the new repository as well as any NixOS related key terms in the documentation.

Fixes #5 

## Type of change

Please delete options that are not relevant.

- [x] Documentation change (non-impact change which absolutely does not alter build output)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

N/A
